### PR TITLE
Use regular paragraphs in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
-* **Please check if the PR fulfills these requirements**
+**Please check if the PR fulfills these requirements**
 - [ ] The commit message follows our guidelines
 - [ ] Tests for the changes have been added (for bug fixes/features)
 - [ ] Docs have been added/updated (for bug fixes/features)
 
 
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 
 
 
-* **What is the current behavior?** (You can also link to an open issue here)
+**What is the current behavior?** (You can also link to an open issue here)
 
 
 
-* **What is the new behavior (if this is a feature change)?**
+**What is the new behavior (if this is a feature change)?**
 
 
 
-* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 
 
 
-* **Other information**:
+**Other information**:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Cosmetic changes to the PR template.

**What is the current behavior?**
The questions in the PR template are displayed as list items.

**What is the new behavior?**
The questions in the PR template are regular paragraphs.

**Does this PR introduce a breaking change?**
Nope.

**Other information**:
_Why?_ The current PR template formatting works well for [short PR descriptions](https://github.com/inpsyde/generator-inpsyde/pull/73) but quickly breaks for [more detailed ones](https://github.com/inpsyde/generator-inpsyde/pull/113).

With this change, the PR template is more aligned with the issue templates. Where similarly, the points that have to be addressed are bolded paragraphs.