### PR TITLE
docs: mention response times in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,12 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue 
-with the owners of this repository before making a change.
+First of all, thank you for your interest in contributing to (one of) Inpsyde's public repos. We greatly appreciate your feedback, suggestions and code contributions. 
+When contributing to any repository, please first discuss the change you wish to make with the owners of this repository via an Issue, a Pull Request, or both.
 
-Please note we have a [code of conduct](./CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Since Inpsyders need to prioritize their day-to-day work for our client projects and products over the maintenance of public repositories, the responsible maintainers might not be able to respond to your requests or comments straight away. Still, as a rule, we try to respond to requests within a week. If you have been waiting for longer than two weeks, it's OK to post a friendly reminder in the issue thread.
+
+On that note: we have a [code of conduct](./CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+
 
 ## Pull Request Process
 


### PR DESCRIPTION
To better manage expectations when it comes to our response times, this commit adds a paragraph to address this.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update.


**What is the current behavior?** (You can also link to an open issue here)
We do not mention response times in the CONTRIBUTING.md.


**What is the new behavior (if this is a feature change)?**
Explain how we prioritize client / product work and have one week as a rule, asking contributors/commenters to wait two weeks before they send a friendly nudge.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, just a commitment.

