### PR TITLE
Reword the section on our commit message format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,5 @@ When working on this repository, we encourage you to follow the [7 rules of a gr
 6. Wrap the body at 72 characters
 7. Use the body to explain what and why vs. how
 
-While our company standard is based upon these seven rules, we do not enforce any commit message format standard at Inpsyde. Do not be surprised if you encounter slightly different formats being used in our projects. For example: we do allow prefixes in the commit message header like 'fix:' or 'feat:', as prescribed by [Conventional Commits](https://www.conventionalcommits.org), on repositories that rely on it for release automation. 
+While our company standard is based upon these seven rules, do not be surprised if you encounter slightly different formats being used in our projects. Some of our public projects were created years ago, in a time where we did many things differently, including the composition of commit messages. Currently, we also allow prefixes in the commit message header for repositories that rely on those prefixes for release automation. Still, this is something you might not see in use on the repository you may be interested in.  
 The most important thing to remember is to use common sense and write clear and concise commit messages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,47 +44,15 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 ## <a name="commit"></a> Commit Message Format
 
-When working on this repository, we encourage you to adhere to the following commit message format. Following this convention will lead to an **easier to read commit history** and is especially helpful in projects that use automated release versioning.
+When working on this repository, we encourage you to follow the [7 rules of a great commit message](https://cbea.ms/git-commit/#seven-rules):
 
-*Note: commit message formats are still under review at Inpsyde, so do not be surprised if you different formats being used in our projects. The most important thing to remember is to write clear and concise commit messages. The following specification helps you do exactly that. It is inspired by the [AngularJS commit message format][commit-message-format]. For more information, see [https://www.conventionalcommits.org](https://www.conventionalcommits.org).*
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Capitalize the subject line
+4. Do not end the subject line with a period
+5. Use the imperative mood in the subject line
+6. Wrap the body at 72 characters
+7. Use the body to explain what and why vs. how
 
-
-Each commit message consists of a **header**, a **body**, and a **footer**.
-
-
-```
-<header>
-<BLANK LINE>
-<body>
-<BLANK LINE>
-<footer>
-```
-
-The `header` is mandatory and must conform to the [Commit Message Header](#commit-header) format.
-
-Any line of the commit message cannot be longer than 100 characters.
-
-#### <a name="commit-header"></a>Commit Message Header
-
-```
-<type>: <short summary>
-  │             │
-  │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
-  │
-  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
-```
-
-The `<type>` and `<summary>` fields are mandatory.
-
-##### Type
-
-Must be one of the following:
-
-* **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-* **ci**: Changes to our CI configuration files and scripts (example scopes: Github Action)
-* **docs**: Documentation only changes
-* **feat**: A new feature
-* **fix**: A bug fix
-* **perf**: A code change that improves performance
-* **refactor**: A code change that neither fixes a bug nor adds a feature
-* **test**: Adding missing tests or correcting existing tests
+While our company standard is based upon these seven rules, we do not enforce any commit message format standard at Inpsyde. Do not be surprised if you encounter slightly different formats being used in our projects. For example: we do allow prefixes in the commit message header like 'fix:' or 'feat:', as prescribed by [Conventional Commits](https://www.conventionalcommits.org), on repositories that rely on it for release automation. 
+The most important thing to remember is to use common sense and write clear and concise commit messages.


### PR DESCRIPTION
The section "Commit Message Format" previously recommended to use Conventional Commits. This has been changed because most teams in our organization do not use prefixes in their projects. Instead, we follow a standard based upon the '7 rules of a great commit message' once defined by Chris Beams.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A change in how we ask contributors to format their commit messages.


**What is the current behavior?** (You can also link to an open issue here)
We point to the rules laid out by the Conventional Commits standard


**What is the new behavior (if this is a feature change)?**
The document emphasizes common sense and points to these '7 rules':
```
Adjust the Commit Message section to our current standard
Separate subject from body with a blank line
Limit the subject line to 50 characters
Capitalize the subject line
Do not end the subject line with a period
Use the imperative mood in the subject line
Wrap the body at 72 characters
Use the body to explain what and why vs. how
```

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
